### PR TITLE
Add React app for Spotify playlist analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Spotify Analyzer
+
+This project is a minimal React + Vite application written in TypeScript. It connects to the Spotify Web API to analyse a user's listening history and create monthly playlists.
+
+## Setup
+
+1. Install dependencies (requires internet access):
+
+```bash
+npm install
+```
+
+2. Start the development server:
+
+```bash
+npm run dev
+```
+
+3. Open the app in your browser and provide a Spotify access token with the following scopes:
+
+- `user-read-recently-played`
+- `playlist-modify-public` or `playlist-modify-private`
+
+The app will fetch your recent listening history, group tracks by month, and allow you to create playlists for each month.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spotify Analyzer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "spotify-analyzer",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "typescript": "^5.0.4",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^5.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react'
+import {
+  fetchProfile,
+  fetchRecentlyPlayed,
+  groupTracksByMonth,
+  createPlaylist
+} from './spotify'
+
+function App() {
+  const [token, setToken] = useState('')
+  const [user, setUser] = useState<any>(null)
+  const [playlists, setPlaylists] = useState<any[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  async function analyze() {
+    setError('')
+    setLoading(true)
+    try {
+      const profile = await fetchProfile(token)
+      setUser(profile)
+      const now = new Date()
+      const startYear = now.getFullYear()
+      const startMonth = now.getMonth() - 11
+      let after = new Date(startYear, startMonth, 1).getTime()
+      const tracks = []
+      while (true) {
+        const batch = await fetchRecentlyPlayed(token, after)
+        if (!batch.length) break
+        tracks.push(...batch)
+        const last = batch[batch.length - 1]
+        after = last.playedAt.getTime() + 1000
+        if (tracks.length > 1000) break
+      }
+      const groups = groupTracksByMonth(tracks)
+      setPlaylists(groups)
+    } catch (e: any) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function create(month: string, uris: string[]) {
+    if (!user) return
+    try {
+      await createPlaylist(token, user.id, `Monthly ${month}`, uris)
+      alert(`Playlist for ${month} created!`)
+    } catch (e: any) {
+      alert(`Failed to create playlist: ${e.message}`)
+    }
+  }
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Spotify Monthly Playlist Creator</h1>
+      <p>Enter a Spotify access token with the necessary scopes.</p>
+      <input
+        type="text"
+        value={token}
+        onChange={e => setToken(e.target.value)}
+        placeholder="Access Token"
+        style={{ width: '100%' }}
+      />
+      <button onClick={analyze} disabled={!token || loading}>
+        Analyze Profile
+      </button>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      {loading && <p>Loading...</p>}
+      {user && <p>Logged in as {user.display_name}</p>}
+      {playlists.map(p => (
+        <div key={p.month} style={{ marginTop: '1rem' }}>
+          <h3>{p.month}</h3>
+          <p>{p.tracks.length} tracks</p>
+          <button onClick={() => create(p.month, p.tracks.map(t => `spotify:track:${t.id}`))}>
+            Create Playlist
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default App

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,6 @@
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background-color: #121212;
+  color: #fff;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/src/spotify.ts
+++ b/src/spotify.ts
@@ -1,0 +1,81 @@
+export interface Track {
+  id: string
+  name: string
+  artists: string[]
+  playedAt: Date
+}
+
+export interface PlaylistData {
+  month: string
+  tracks: Track[]
+}
+
+export async function fetchProfile(token: string) {
+  const res = await fetch('https://api.spotify.com/v1/me', {
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  if (!res.ok) throw new Error('Failed to fetch profile')
+  return await res.json()
+}
+
+export async function fetchRecentlyPlayed(token: string, after: number) {
+  const url = new URL('https://api.spotify.com/v1/me/player/recently-played')
+  url.searchParams.set('limit', '50')
+  if (after) url.searchParams.set('after', String(after))
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  if (!res.ok) throw new Error('Failed to fetch tracks')
+  const data = await res.json()
+  return data.items.map((item: any) => ({
+    id: item.track.id,
+    name: item.track.name,
+    artists: item.track.artists.map((a: any) => a.name),
+    playedAt: new Date(item.played_at)
+  })) as Track[]
+}
+
+export function groupTracksByMonth(tracks: Track[]): PlaylistData[] {
+  const map = new Map<string, Track[]>()
+  for (const t of tracks) {
+    const month = `${t.playedAt.getFullYear()}-${(t.playedAt.getMonth() + 1)
+      .toString()
+      .padStart(2, '0')}`
+    if (!map.has(month)) map.set(month, [])
+    map.get(month)!.push(t)
+  }
+  return Array.from(map.entries()).map(([month, tracks]) => ({ month, tracks }))
+}
+
+export async function createPlaylist(
+  token: string,
+  userId: string,
+  name: string,
+  trackUris: string[]
+) {
+  const res = await fetch(`https://api.spotify.com/v1/users/${userId}/playlists`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ name })
+  })
+  if (!res.ok) throw new Error('Failed to create playlist')
+  const playlist = await res.json()
+  if (trackUris.length) {
+    const addRes = await fetch(
+      `https://api.spotify.com/v1/playlists/${playlist.id}/tracks`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ uris: trackUris })
+      }
+    )
+    if (!addRes.ok) throw new Error('Failed to add tracks')
+  }
+  return playlist
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+})


### PR DESCRIPTION
## Summary
- initialize Vite React TypeScript project
- add Spotify API helper functions
- create simple UI to analyze history and create playlists
- document setup steps in README

## Testing
- `npm run build` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684f2cd528c883229d107c373382ba3d