### PR TITLE
Add Spotify login support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ npm install
 npm run dev
 ```
 
-3. Open the app in your browser and provide a Spotify access token with the following scopes:
+3. Add your Spotify application client ID to `src/auth.ts`.
+
+4. Open the app in your browser and click **Login with Spotify**. Authorize the requested scopes when prompted:
 
 - `user-read-recently-played`
 - `playlist-modify-public` or `playlist-modify-private`
 
-The app will fetch your recent listening history, group tracks by month, and allow you to create playlists for each month.
+After logging in, the app will fetch your recent listening history, group tracks by month, and allow you to create playlists for each month.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import {
   fetchProfile,
   fetchRecentlyPlayed,
   groupTracksByMonth,
   createPlaylist
 } from './spotify'
+import { login, logout, getStoredToken } from './auth'
 
 function App() {
   const [token, setToken] = useState('')
@@ -12,6 +13,11 @@ function App() {
   const [playlists, setPlaylists] = useState<any[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
+
+  useEffect(() => {
+    const stored = getStoredToken()
+    if (stored) setToken(stored)
+  }, [])
 
   async function analyze() {
     setError('')
@@ -54,17 +60,16 @@ function App() {
   return (
     <div style={{ padding: '1rem' }}>
       <h1>Spotify Monthly Playlist Creator</h1>
-      <p>Enter a Spotify access token with the necessary scopes.</p>
-      <input
-        type="text"
-        value={token}
-        onChange={e => setToken(e.target.value)}
-        placeholder="Access Token"
-        style={{ width: '100%' }}
-      />
-      <button onClick={analyze} disabled={!token || loading}>
-        Analyze Profile
-      </button>
+      {!token ? (
+        <button onClick={login}>Login with Spotify</button>
+      ) : (
+        <>
+          <button onClick={logout}>Logout</button>
+          <button onClick={analyze} disabled={loading}>
+            Analyze Profile
+          </button>
+        </>
+      )}
       {error && <p style={{ color: 'red' }}>{error}</p>}
       {loading && <p>Loading...</p>}
       {user && <p>Logged in as {user.display_name}</p>}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,34 @@
+export const CLIENT_ID = '<YOUR_SPOTIFY_CLIENT_ID>'
+export const REDIRECT_URI = window.location.origin
+export const SCOPES = [
+  'user-read-recently-played',
+  'playlist-modify-public',
+  'playlist-modify-private'
+].join(' ')
+
+export function login() {
+  const url = new URL('https://accounts.spotify.com/authorize')
+  url.searchParams.set('client_id', CLIENT_ID)
+  url.searchParams.set('response_type', 'token')
+  url.searchParams.set('redirect_uri', REDIRECT_URI)
+  url.searchParams.set('scope', SCOPES)
+  url.searchParams.set('show_dialog', 'true')
+  window.location.assign(url.toString())
+}
+
+export function logout() {
+  localStorage.removeItem('spotify_token')
+}
+
+export function getStoredToken(): string | null {
+  if (window.location.hash.startsWith('#access_token=')) {
+    const params = new URLSearchParams(window.location.hash.substring(1))
+    const token = params.get('access_token')
+    if (token) {
+      localStorage.setItem('spotify_token', token)
+      window.location.hash = ''
+      return token
+    }
+  }
+  return localStorage.getItem('spotify_token')
+}


### PR DESCRIPTION
## Summary
- implement OAuth login helper
- add login and logout controls in the UI
- document login setup in README

## Testing
- `npm run build` *(fails: Cannot find module 'react')*
- `tsc --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684f2f510f7c8322be8309725fdbdb53