### PR TITLE
Fix login redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ npm run dev
 
 3. Add your Spotify application client ID to `src/auth.ts`.
 
-4. Make sure your redirect URI uses `https`. The provided helper automatically replaces `http` with `https` during login.
-
-5. Open the app in your browser and click **Login with Spotify**. Authorize the requested scopes when prompted:
+4. Open the app in your browser and click **Login with Spotify**. Authorize the requested scopes when prompted:
 
 
 - `user-read-recently-played`

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,6 +1,6 @@
 export const CLIENT_ID = '26f584098dae4d02b5647086929b483b';
-// Force HTTPS for the redirect to avoid mixed content issues
-export const REDIRECT_URI = window.location.origin.replace(/^http:/, 'https:');
+// Redirect back to the current origin after auth
+export const REDIRECT_URI = window.location.origin;
 export const SCOPES = [
     'user-read-recently-played',
     'playlist-modify-public',

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,6 @@
 export const CLIENT_ID = '26f584098dae4d02b5647086929b483b'
-// Force HTTPS for the redirect to avoid mixed content issues
-export const REDIRECT_URI = window.location.origin.replace(/^http:/, 'https:')
+// Redirect back to the current origin after auth
+export const REDIRECT_URI = window.location.origin
 
 export const SCOPES = [
   'user-read-recently-played',


### PR DESCRIPTION
## Summary
- remove HTTPS redirect enforcement in auth helper
- update README instructions accordingly

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684f385bd01483229159bfbb6b909654