### PR TITLE
Fix login redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm run dev
 
 3. Add your Spotify application client ID to `src/auth.ts`.
 
-4. Make sure your redirect URI uses `https`. The provided helper automatically replaces `http` with `https` during login.
+4. In the Spotify Developer Dashboard, add `http://127.0.0.1:5173` (or another loopback address) to your allowed redirect URIs for local development. **Do not use `localhost` as it is rejected by Spotify.** The value must exactly match `REDIRECT_URI` in `src/auth.ts`. Use `https://` for any non-loopback address.
 
 5. Open the app in your browser and click **Login with Spotify**. Authorize the requested scopes when prompted:
 

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,6 +1,11 @@
 export const CLIENT_ID = '26f584098dae4d02b5647086929b483b';
-// Force HTTPS for the redirect to avoid mixed content issues
-export const REDIRECT_URI = window.location.origin.replace(/^http:/, 'https:');
+// Redirect back to the current origin after auth.
+// This must match a URI whitelisted in your Spotify app settings and use HTTPS
+// unless the host is a loopback IP.
+const isLoopback = /^(127\.0\.0\.1|\[::1\])$/.test(window.location.hostname);
+export const REDIRECT_URI = isLoopback
+    ? window.location.origin
+    : window.location.origin.replace(/^http:/, 'https:');
 export const SCOPES = [
     'user-read-recently-played',
     'playlist-modify-public',

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,11 @@
 export const CLIENT_ID = '26f584098dae4d02b5647086929b483b'
-// Force HTTPS for the redirect to avoid mixed content issues
-export const REDIRECT_URI = window.location.origin.replace(/^http:/, 'https:')
+// Redirect back to the current origin after auth.
+// This must match a URI whitelisted in your Spotify app settings and use HTTPS
+// unless the host is a loopback IP.
+const isLoopback = /^(127\.0\.0\.1|\[::1\])$/.test(window.location.hostname)
+export const REDIRECT_URI = isLoopback
+  ? window.location.origin
+  : window.location.origin.replace(/^http:/, 'https:')
 
 export const SCOPES = [
   'user-read-recently-played',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: '127.0.0.1',
     port: 5173
   }
 })


### PR DESCRIPTION
## Summary
- clarify the required redirect URI setup in the README
- note that `REDIRECT_URI` must match an entry in the Spotify dashboard

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684f385bd01483229159bfbb6b909654