### PR TITLE
Add cross-genre playlist feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ npm run dev
 - `user-read-recently-played`
 - `playlist-modify-public` or `playlist-modify-private`
 
-After logging in, the app will fetch your recent listening history, group tracks by month, and allow you to create playlists for each month.
+After logging in, the app will fetch your recent listening history, group tracks by month, and allow you to create playlists for each month. Tracks that belong to multiple genres are placed in a separate "Shared Across Genres" playlist to avoid duplicates in the genre lists.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import {
   fetchRecentlyPlayed,
   groupTracksByMonth,
   groupTracksByGenre,
+  groupTracksByGenreDedup,
   createPlaylist,
   PlaylistGroup,
   GenreGroup,
@@ -18,6 +19,7 @@ function App() {
   const [user, setUser] = useState<any>(null)
   const [playlists, setPlaylists] = useState<PlaylistGroup[]>([])
   const [genres, setGenres] = useState<GenreGroup[]>([])
+  const [duplicates, setDuplicates] = useState<Track[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
@@ -53,8 +55,9 @@ function App() {
       }
       const groups = groupTracksByMonth(tracks)
       setPlaylists(groups)
-      const genreGroups = groupTracksByGenre(tracks)
-      setGenres(genreGroups)
+      const genreResult = groupTracksByGenreDedup(tracks)
+      setGenres(genreResult.genres)
+      setDuplicates(genreResult.duplicates)
     } catch (e: any) {
       setError(e.message)
     } finally {
@@ -106,6 +109,22 @@ function App() {
       ))}
 
       {genres.length > 0 && <h2>Detected Genres</h2>}
+      {duplicates.length > 0 && (
+        <div style={{ marginTop: '1rem' }}>
+          <h3>Shared Across Genres</h3>
+          <p>{duplicates.length} tracks</p>
+          <button
+            onClick={() =>
+              create(
+                'Shared Across Genres',
+                duplicates.map(t => `spotify:track:${t.id}`)
+              )
+            }
+          >
+            Create Playlist
+          </button>
+        </div>
+      )}
       {genres.map(g => (
         <div key={g.genre} style={{ marginTop: '1rem' }}>
           <h3>

--- a/src/spotify.ts
+++ b/src/spotify.ts
@@ -19,6 +19,11 @@ export interface GenreGroup {
   tracks: Track[]
 }
 
+export interface GenreGroupingResult {
+  genres: GenreGroup[]
+  duplicates: Track[]
+}
+
 export interface Profile {
   id: string
   display_name: string
@@ -116,6 +121,42 @@ export function groupTracksByGenre(tracks: Track[]): GenreGroup[] {
     genre,
     tracks
   }))
+}
+
+export function groupTracksByGenreDedup(tracks: Track[]): GenreGroupingResult {
+  const groups: { [genre: string]: Track[] } = {}
+  const trackGenres: Record<string, Set<string>> = {}
+  const trackMap: Record<string, Track> = {}
+
+  for (const track of tracks) {
+    trackMap[track.id] = track
+    if (!track.genres.length) continue
+    const uniqueGenres = Array.from(new Set(track.genres))
+    for (const genre of uniqueGenres) {
+      if (!groups[genre]) groups[genre] = []
+      groups[genre].push(track)
+      if (!trackGenres[track.id]) trackGenres[track.id] = new Set()
+      trackGenres[track.id].add(genre)
+    }
+  }
+
+  const duplicateIds = new Set<string>()
+  for (const id in trackGenres) {
+    if (trackGenres[id].size > 1) duplicateIds.add(id)
+  }
+
+  const duplicates: Track[] = Array.from(duplicateIds).map(id => trackMap[id])
+
+  for (const genre in groups) {
+    groups[genre] = groups[genre].filter(t => !duplicateIds.has(t.id))
+  }
+
+  const genres = Object.entries(groups).map(([genre, tracks]) => ({
+    genre,
+    tracks
+  }))
+
+  return { genres, duplicates }
 }
 
 export async function createPlaylist(token: string, userId: string, name: string, uris: string[]) {


### PR DESCRIPTION
## Summary
- keep tracks appearing in multiple genres in a single "Shared Across Genres" playlist
- update genre grouping logic to remove duplicates
- display cross-genre playlist in the UI
- document the new behaviour in the README