### PR TITLE
Fix duplicate genre grouping

### DIFF
--- a/src/spotify.ts
+++ b/src/spotify.ts
@@ -198,41 +198,6 @@ export function groupTracksByGenreDedup(tracks: Track[]): GenreGroupingResult {
   return { genres, duplicates }
 }
 
-export function groupTracksByGenreDedup(tracks: Track[]): GenreGroupingResult {
-  const groups: { [genre: string]: Track[] } = {}
-  const trackGenres: Record<string, Set<string>> = {}
-  const trackMap: Record<string, Track> = {}
-
-  for (const track of tracks) {
-    trackMap[track.id] = track
-    if (!track.genres.length) continue
-    const uniqueGenres = Array.from(new Set(track.genres))
-    for (const genre of uniqueGenres) {
-      if (!groups[genre]) groups[genre] = []
-      groups[genre].push(track)
-      if (!trackGenres[track.id]) trackGenres[track.id] = new Set()
-      trackGenres[track.id].add(genre)
-    }
-  }
-
-  const duplicateIds = new Set<string>()
-  for (const id in trackGenres) {
-    if (trackGenres[id].size > 1) duplicateIds.add(id)
-  }
-
-  const duplicates: Track[] = Array.from(duplicateIds).map(id => trackMap[id])
-
-  for (const genre in groups) {
-    groups[genre] = groups[genre].filter(t => !duplicateIds.has(t.id))
-  }
-
-  const genres = Object.entries(groups).map(([genre, tracks]) => ({
-    genre,
-    tracks
-  }))
-
-  return { genres, duplicates }
-}
 
 export async function createPlaylist(token: string, userId: string, name: string, uris: string[]) {
   const uniqueUris = Array.from(new Set(uris))


### PR DESCRIPTION
## Summary
- remove duplicate `groupTracksByGenreDedup` implementation so similar genres are collapsed properly

## Testing
- `npm run build` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684f4e489cc88322b3900307a9d9f683