### PR TITLE
Improve genre canonicalization

### DIFF
--- a/src/spotify.ts
+++ b/src/spotify.ts
@@ -31,17 +31,68 @@ export interface GenreGroupingResult {
  * genres such as "hip-hop" and "rap".
  */
 function canonicalGenre(name: string): string {
-  const lower = name.toLowerCase()
-  if (lower.includes('hip hop') || lower.includes('hip-hop') || lower === 'rap') {
+  const lower = name
+    .toLowerCase()
+    .replace(/-/g, ' ')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+
+  // hip hop / rap variations
+  if (
+    lower.includes('hip hop') ||
+    lower.includes('hiphop') ||
+    lower.includes('rap')
+  ) {
     return 'hip hop'
   }
-  if (lower.includes('rock')) return 'rock'
-  if (lower.includes('electro') || lower.includes('edm') || lower.includes('dance')) {
+
+  // rock and related subgenres
+  if (
+    lower.includes('rock') ||
+    lower.includes('punk') ||
+    lower.includes('metal') ||
+    lower.includes('grunge') ||
+    lower.includes('indie')
+  ) {
+    return 'rock'
+  }
+
+  // electronic music umbrella
+  if (
+    lower.includes('electro') ||
+    lower.includes('edm') ||
+    lower.includes('dance') ||
+    lower.includes('house') ||
+    lower.includes('techno') ||
+    lower.includes('electronica')
+  ) {
     return 'electronic'
   }
-  if (lower.includes('r&b') || lower.includes('rnb')) return 'r&b'
+
+  // r&b variations
+  if (lower.includes('r&b') || lower.includes('rnb') || lower.includes('soul')) {
+    return 'r&b'
+  }
+
+  // jazz styles
+  if (
+    lower.includes('jazz') ||
+    lower.includes('bop') ||
+    lower.includes('swing') ||
+    lower.includes('big band') ||
+    lower.includes('bossa nova') ||
+    (lower.includes('fusion') && lower.includes('jazz')) ||
+    lower.includes('lounge')
+  ) {
+    return 'jazz'
+  }
+
+  if (lower.includes('navidad') || lower.includes('christmas')) {
+    return 'christmas'
+  }
+
   if (lower.includes('pop')) return 'pop'
-  return lower
+  return lower.trim()
 }
 export interface Profile {
   id: string
@@ -198,41 +249,6 @@ export function groupTracksByGenreDedup(tracks: Track[]): GenreGroupingResult {
   return { genres, duplicates }
 }
 
-export function groupTracksByGenreDedup(tracks: Track[]): GenreGroupingResult {
-  const groups: { [genre: string]: Track[] } = {}
-  const trackGenres: Record<string, Set<string>> = {}
-  const trackMap: Record<string, Track> = {}
-
-  for (const track of tracks) {
-    trackMap[track.id] = track
-    if (!track.genres.length) continue
-    const uniqueGenres = Array.from(new Set(track.genres))
-    for (const genre of uniqueGenres) {
-      if (!groups[genre]) groups[genre] = []
-      groups[genre].push(track)
-      if (!trackGenres[track.id]) trackGenres[track.id] = new Set()
-      trackGenres[track.id].add(genre)
-    }
-  }
-
-  const duplicateIds = new Set<string>()
-  for (const id in trackGenres) {
-    if (trackGenres[id].size > 1) duplicateIds.add(id)
-  }
-
-  const duplicates: Track[] = Array.from(duplicateIds).map(id => trackMap[id])
-
-  for (const genre in groups) {
-    groups[genre] = groups[genre].filter(t => !duplicateIds.has(t.id))
-  }
-
-  const genres = Object.entries(groups).map(([genre, tracks]) => ({
-    genre,
-    tracks
-  }))
-
-  return { genres, duplicates }
-}
 
 export async function createPlaylist(token: string, userId: string, name: string, uris: string[]) {
   const uniqueUris = Array.from(new Set(uris))


### PR DESCRIPTION
## Summary
- broaden canonicalGenre mapping for jazz styles and holiday labels
- convert input to normalized characters before matching

## Testing
- `npm run build` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684f4e489cc88322b3900307a9d9f683