### PR TITLE
Refine genre canonicalization

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,14 @@
 import { jsx as _jsx, Fragment as _Fragment, jsxs as _jsxs } from "react/jsx-runtime";
 // App.tsx
 import { useState, useEffect } from 'react';
-import { fetchProfile, fetchRecentlyPlayed, groupTracksByMonth, groupTracksByGenre, createPlaylist } from './spotify';
+import { fetchProfile, fetchRecentlyPlayed, groupTracksByMonth, groupTracksByGenreDedup, createPlaylist } from './spotify';
 import { login, logout, getStoredToken } from './auth';
 function App() {
     const [token, setToken] = useState('');
     const [user, setUser] = useState(null);
     const [playlists, setPlaylists] = useState([]);
     const [genres, setGenres] = useState([]);
+    const [duplicates, setDuplicates] = useState([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState('');
     function summarizeArtists(tracks, limit = 3) {
@@ -43,8 +44,9 @@ function App() {
             }
             const groups = groupTracksByMonth(tracks);
             setPlaylists(groups);
-            const genreGroups = groupTracksByGenre(tracks);
-            setGenres(genreGroups);
+            const genreResult = groupTracksByGenreDedup(tracks);
+            setGenres(genreResult.genres);
+            setDuplicates(genreResult.duplicates);
         }
         catch (e) {
             setError(e.message);
@@ -64,6 +66,6 @@ function App() {
             alert(`Failed to create playlist: ${e.message}`);
         }
     }
-    return (_jsxs("div", { style: { padding: '1rem' }, children: [_jsx("h1", { children: "Spotify Monthly Playlist Creator" }), !token ? (_jsx("button", { onClick: login, children: "Login with Spotify" })) : (_jsxs(_Fragment, { children: [_jsx("button", { onClick: logout, children: "Logout" }), _jsx("button", { onClick: analyze, disabled: loading, children: "Analyze Profile" })] })), error && _jsx("p", { style: { color: 'red' }, children: error }), loading && _jsx("p", { children: "Loading..." }), user && _jsxs("p", { children: ["Logged in as ", user.display_name] }), playlists.map(p => (_jsxs("div", { style: { marginTop: '1rem' }, children: [_jsx("h3", { children: p.month }), _jsxs("p", { children: [p.tracks.length, " tracks"] }), _jsx("button", { onClick: () => create(`Monthly ${p.month}`, p.tracks.map(t => `spotify:track:${t.id}`)), children: "Create Playlist" })] }, p.month))), genres.length > 0 && _jsx("h2", { children: "Detected Genres" }), genres.map(g => (_jsxs("div", { style: { marginTop: '1rem' }, children: [_jsxs("h3", { children: [g.genre, g.tracks.length > 0 && ' - ' + summarizeArtists(g.tracks)] }), _jsxs("p", { children: [g.tracks.length, " tracks"] }), _jsx("button", { onClick: () => create(`Genre ${g.genre}`, g.tracks.map(t => `spotify:track:${t.id}`)), children: "Create Playlist" })] }, g.genre)))] }));
+    return (_jsxs("div", { style: { padding: '1rem' }, children: [_jsx("h1", { children: "Spotify Monthly Playlist Creator" }), !token ? (_jsx("button", { onClick: login, children: "Login with Spotify" })) : (_jsxs(_Fragment, { children: [_jsx("button", { onClick: logout, children: "Logout" }), _jsx("button", { onClick: analyze, disabled: loading, children: "Analyze Profile" })] })), error && _jsx("p", { style: { color: 'red' }, children: error }), loading && _jsx("p", { children: "Loading..." }), user && _jsxs("p", { children: ["Logged in as ", user.display_name] }), playlists.map(p => (_jsxs("div", { style: { marginTop: '1rem' }, children: [_jsx("h3", { children: p.month }), _jsxs("p", { children: [p.tracks.length, " tracks"] }), _jsx("button", { onClick: () => create(`Monthly ${p.month}`, Array.from(new Set(p.tracks.map(t => `spotify:track:${t.id}`)))), children: "Create Playlist" })] }, p.month))), genres.length > 0 && _jsx("h2", { children: "Detected Genres" }), duplicates.length > 0 && (_jsxs("div", { style: { marginTop: '1rem' }, children: [_jsx("h3", { children: "Shared Across Genres" }), _jsxs("p", { children: [duplicates.length, " tracks"] }), _jsx("button", { onClick: () => create('Shared Across Genres', Array.from(new Set(duplicates.map(t => `spotify:track:${t.id}`)))), children: "Create Playlist" })] })), genres.map(g => (_jsxs("div", { style: { marginTop: '1rem' }, children: [_jsxs("h3", { children: [g.genre, g.tracks.length > 0 && ' - ' + summarizeArtists(g.tracks)] }), _jsxs("p", { children: [g.tracks.length, " tracks"] }), _jsx("button", { onClick: () => create(`Genre ${g.genre}`, Array.from(new Set(g.tracks.map(t => `spotify:track:${t.id}`)))), children: "Create Playlist" })] }, g.genre)))] }));
 }
 export default App;

--- a/src/spotify.ts
+++ b/src/spotify.ts
@@ -28,20 +28,78 @@ export interface GenreGroupingResult {
 /**
  * Map similar or synonymous genre names to a canonical representation.
  * This reduces duplication when an artist has multiple closely related
- * genres such as "hip-hop" and "rap".
+ * styles such as "hip-hop" and "rap" or many jazz subgenres.
+ * Accents and hyphens are removed before matching to handle labels like
+ * "rock clásico" or "jazz fusión".
  */
 function canonicalGenre(name: string): string {
-  const lower = name.toLowerCase()
-  if (lower.includes('hip hop') || lower.includes('hip-hop') || lower === 'rap') {
+  const lower = name
+    .toLowerCase()
+    .replace(/-/g, ' ')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+
+  // hip hop / rap variations
+  if (
+    lower.includes('hip hop') ||
+    lower.includes('hiphop') ||
+    lower.includes('rap')
+  ) {
     return 'hip hop'
   }
-  if (lower.includes('rock')) return 'rock'
-  if (lower.includes('electro') || lower.includes('edm') || lower.includes('dance')) {
+
+  // rock and related subgenres
+  if (
+    lower.includes('rock') ||
+    lower.includes('punk') ||
+    lower.includes('metal') ||
+    lower.includes('grunge') ||
+    lower.includes('indie')
+  ) {
+    return 'rock'
+  }
+
+  // electronic music umbrella
+  if (
+    lower.includes('electro') ||
+    lower.includes('edm') ||
+    lower.includes('dance') ||
+    lower.includes('house') ||
+    lower.includes('techno') ||
+    lower.includes('electronica')
+  ) {
     return 'electronic'
   }
-  if (lower.includes('r&b') || lower.includes('rnb')) return 'r&b'
+
+  // jazz styles
+  if (
+    lower.includes('jazz') ||
+    lower.includes('bop') ||
+    lower.includes('swing') ||
+    lower.includes('big band') ||
+    lower.includes('bossa nova') ||
+    lower.includes('latin jazz') ||
+    lower.includes('jazz latino') ||
+    lower.includes('jazz funk') ||
+    lower.includes('soul jazz') ||
+    lower.includes('smooth jazz') ||
+    (lower.includes('fusion') && lower.includes('jazz')) ||
+    lower.includes('lounge')
+  ) {
+    return 'jazz'
+  }
+
+  // r&b variations
+  if (lower.includes('r&b') || lower.includes('rnb') || lower.includes('soul')) {
+    return 'r&b'
+  }
+
+  if (lower.includes('navidad') || lower.includes('christmas')) {
+    return 'christmas'
+  }
+
   if (lower.includes('pop')) return 'pop'
-  return lower
+  return lower.trim()
 }
 export interface Profile {
   id: string
@@ -198,41 +256,6 @@ export function groupTracksByGenreDedup(tracks: Track[]): GenreGroupingResult {
   return { genres, duplicates }
 }
 
-export function groupTracksByGenreDedup(tracks: Track[]): GenreGroupingResult {
-  const groups: { [genre: string]: Track[] } = {}
-  const trackGenres: Record<string, Set<string>> = {}
-  const trackMap: Record<string, Track> = {}
-
-  for (const track of tracks) {
-    trackMap[track.id] = track
-    if (!track.genres.length) continue
-    const uniqueGenres = Array.from(new Set(track.genres))
-    for (const genre of uniqueGenres) {
-      if (!groups[genre]) groups[genre] = []
-      groups[genre].push(track)
-      if (!trackGenres[track.id]) trackGenres[track.id] = new Set()
-      trackGenres[track.id].add(genre)
-    }
-  }
-
-  const duplicateIds = new Set<string>()
-  for (const id in trackGenres) {
-    if (trackGenres[id].size > 1) duplicateIds.add(id)
-  }
-
-  const duplicates: Track[] = Array.from(duplicateIds).map(id => trackMap[id])
-
-  for (const genre in groups) {
-    groups[genre] = groups[genre].filter(t => !duplicateIds.has(t.id))
-  }
-
-  const genres = Object.entries(groups).map(([genre, tracks]) => ({
-    genre,
-    tracks
-  }))
-
-  return { genres, duplicates }
-}
 
 export async function createPlaylist(token: string, userId: string, name: string, uris: string[]) {
   const uniqueUris = Array.from(new Set(uris))


### PR DESCRIPTION
## Summary
- prioritize jazz matching before R&B
- expand jazz-related terms like `jazz latino` and `smooth jazz`
- update bundled JS sources to stay in sync

## Testing
- `npm run build` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684f4e489cc88322b3900307a9d9f683